### PR TITLE
Update OTP verification logic

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -661,7 +661,8 @@ async function handleOtpVerification() {
         showAuthMessage(otpVerifyMessage, 'Verifying code...', 'info');
         otpVerifySubmit.disabled = true;
         
-        const { data, error } = await window.SupabaseAuth.verifyOtp(otpEmail, code, 'email');
+        const otpChannel = otpType === 'signup' ? 'signup' : 'email';
+        const { data, error } = await window.SupabaseAuth.verifyOtp(otpEmail, code, otpChannel);
         
         if (error) {
             showAuthMessage(otpVerifyMessage, error, 'error');


### PR DESCRIPTION
## Summary
- update OTP verification to use signup channel when verifying signup codes

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684091a6bd848322a6275cb367b823cb