### PR TITLE
Inject Supabase credentials via env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ TESTING_GUIDE.md
 *.gz
 .cursor/
 TESTING_GUIDE.md
+supabase-client.js

--- a/build-supabase.js
+++ b/build-supabase.js
@@ -3,6 +3,30 @@ const path = require('path');
 
 console.log('🔄 Building Supabase library for Chrome extension...');
 
+// Generate supabase-client.js from template using environment variables
+const url = process.env.SUPABASE_URL;
+const anonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+    console.error('❌ SUPABASE_URL or SUPABASE_ANON_KEY environment variables are missing.');
+    process.exit(1);
+}
+
+const templatePath = path.join(__dirname, 'supabase-client.template.js');
+const clientDestPath = path.join(__dirname, 'supabase-client.js');
+
+try {
+    let clientContent = fs.readFileSync(templatePath, 'utf8');
+    clientContent = clientContent
+        .replace('__SUPABASE_URL__', url)
+        .replace('__SUPABASE_ANON_KEY__', anonKey);
+    fs.writeFileSync(clientDestPath, clientContent);
+    console.log('✅ Generated supabase-client.js from template');
+} catch (err) {
+    console.error('❌ Failed to generate supabase-client.js:', err.message);
+    process.exit(1);
+}
+
 try {
     // Source path of the Supabase UMD build (corrected path)
     const sourcePath = path.join(__dirname, 'node_modules', '@supabase', 'supabase-js', 'dist', 'umd', 'supabase.js');

--- a/supabase-client.template.js
+++ b/supabase-client.template.js
@@ -9,8 +9,8 @@
 const SUPABASE_CONFIG = {
     // Replace these with your actual Supabase project values
     // Get these from your Supabase dashboard: Settings > API
-    url: 'https://iyfwymlzdwtqruibeujc.supabase.co',
-    anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml5Znd5bWx6ZHd0cXJ1aWJldWpjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4ODcyNzYsImV4cCI6MjA2NDQ2MzI3Nn0.Cb1ouxrsNwr52jPH2F-DdbLzymlEiG4uXtnb5VVqlEg'
+    url: "__SUPABASE_URL__",
+    anonKey: "__SUPABASE_ANON_KEY__",
 };
 
 // ✅ Configuration completed with your Supabase project credentials

--- a/supabase_setup.md
+++ b/supabase_setup.md
@@ -141,8 +141,21 @@ CREATE TRIGGER update_user_settings_updated_at BEFORE UPDATE ON user_settings
 
 1. Go to Settings > API in your Supabase dashboard
 2. Copy the following values (you'll need them in the extension):
-   - Project URL
-   - Project API Key (anon/public key)
+ - Project URL
+ - Project API Key (anon/public key)
+
+### Configure build environment
+
+Export these credentials as environment variables before running the build
+script:
+
+```bash
+export SUPABASE_URL="https://your-project.supabase.co"
+export SUPABASE_ANON_KEY="your-anon-key"
+```
+
+The `npm run build` command will read these variables and generate
+`supabase-client.js` with the proper credentials.
 
 ## 5. Data Structure Explanation
 


### PR DESCRIPTION
## Summary
- store a template for Supabase client config
- generate `supabase-client.js` at build time from env vars
- ignore generated client file in git
- document new environment variables in setup instructions

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`
- `npm run package`

------
https://chatgpt.com/codex/tasks/task_e_6840920296548322a9333a6ed2c0bdfa