### PR TITLE
Update manifest and iframe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ npm run build    # Build Supabase client
 3. Click "Load unpacked"
 4. Select the `build/` directory
 
+## Permissions
+
+The extension requires host permissions for translation APIs as well as Google
+Books reader pages:
+
+- `https://play.google.com/*`
+- `https://books.googleusercontent.com/*`
+
 ## 📝 Available Scripts
 
 - `npm run build` - Build Supabase client from template

--- a/docs/CHROME_STORE_README.md
+++ b/docs/CHROME_STORE_README.md
@@ -143,6 +143,8 @@ The extension requests these permissions:
 - **storage**: To save user preferences and translation history
 - **scripting**: To add the sidebar to web pages
 - **<all_urls>**: To work on any website (required for translation)
+- **https://play.google.com/** and **https://books.googleusercontent.com/**: To
+  capture selections in Google Books reader pages
 
 **Note**: Cloud sync features load external Supabase library from CDN only when user explicitly enables cloud sync.
 

--- a/src/manifest/manifest.json
+++ b/src/manifest/manifest.json
@@ -16,7 +16,9 @@
     "https://translate.yandex.net/*",
     "https://api.openai.com/*",
     "https://api.anthropic.com/*",
-    "https://generativelanguage.googleapis.com/*"
+    "https://generativelanguage.googleapis.com/*",
+    "https://play.google.com/*",
+    "https://books.googleusercontent.com/*"
   ],
   "background": {
     "service_worker": "background.js",

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -24,7 +24,7 @@ async function ensureContentScriptInjected(tabId) {
         
         try {
             await chrome.scripting.executeScript({
-                target: { tabId: tabId },
+                target: { tabId: tabId, allFrames: true },
                 files: ['content.js']
             });
             

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -3,6 +3,9 @@ if (window.translatorExtensionLoaded) {
     console.log("Pontix content script already loaded, skipping");
 } else {
     window.translatorExtensionLoaded = true;
+
+    // Detect if running inside an iframe
+    const isIframe = window.self !== window.top;
     
     // Version identification for debugging
     console.log("🔄 Pontix v4.0 - Configurable Word Limits Loaded");
@@ -881,7 +884,9 @@ if (window.translatorExtensionLoaded) {
                 isEdgeImmersiveMode = checkEdgeImmersiveMode();
             }
             
-            handleSidebarToggle();
+            if (!isIframe) {
+                handleSidebarToggle();
+            }
             
             // Send a response to let the background script know the message was received
             sendResponse({ success: true });
@@ -1322,6 +1327,19 @@ if (window.translatorExtensionLoaded) {
         // Store for potential later use
         currentWord = word;
         currentSentence = sentence;
+
+        // If running inside an iframe, relay selection to the top frame
+        if (isIframe) {
+            window.top.postMessage({
+                source: 'pontix-frame',
+                text: word,
+                sentence: sentence
+            }, '*');
+
+            lastProcessedSelection = selectedText;
+            window.lastProcessingTime = now;
+            return;
+        }
         
         // Create sidebar if it doesn't exist
         let needsCreation = true;
@@ -1704,6 +1722,42 @@ if (window.translatorExtensionLoaded) {
             }
         }
     });
+
+    // When acting as the top frame, receive selections from child frames
+    if (!isIframe) {
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.source === 'pontix-frame') {
+                const { text, sentence } = event.data;
+                if (!sidebarEnabled) return;
+
+                let needsCreation = true;
+                if (document.getElementById("translator-sidebar")) {
+                    needsCreation = false;
+                } else if (document.getElementById("translator-sidebar-container")) {
+                    needsCreation = false;
+                }
+
+                if (needsCreation) {
+                    if (isEdgeImmersiveMode) {
+                        createImmersiveModeIframe();
+                    } else {
+                        createSidebar();
+                    }
+                    sidebarVisible = true;
+
+                    if (isEdgeImmersiveMode) {
+                        adjustPageForImmersiveMode();
+                    } else {
+                        adjustPageLayoutForReader();
+                    }
+                }
+
+                currentWord = text;
+                currentSentence = sentence;
+                updateSidebar(text, sentence, text);
+            }
+        });
+    }
 
     // Initialize on page load
     initializeExtension();


### PR DESCRIPTION
## Summary
- add Google Books domains to host permissions
- inject content script in all frames
- detect iframe context and relay selections to parent
- handle messages from child frames in the top page
- document new permissions in README and Chrome store notes

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68416f2eef88832281c17c59d8adb102