### PR TITLE
Handle missing Supabase session gracefully

### DIFF
--- a/src/scripts/supabase-client.template.js
+++ b/src/scripts/supabase-client.template.js
@@ -409,7 +409,12 @@ async function getCurrentUser() {
     try {
         const { data: { user }, error } = await client.auth.getUser();
         if (error) {
-            console.error('Get user error:', error);
+            const msg = error.message || '';
+            if (msg.toLowerCase().includes('auth session missing')) {
+                console.log('Get user: no active session');
+            } else {
+                console.error('Get user error:', error);
+            }
             return { data: { user: null }, error: error.message };
         }
         
@@ -431,7 +436,12 @@ async function getCurrentSession() {
     try {
         const { data: { session }, error } = await client.auth.getSession();
         if (error) {
-            console.error('Get session error:', error);
+            const msg = error.message || '';
+            if (msg.toLowerCase().includes('auth session missing')) {
+                console.log('Get session: no active session');
+            } else {
+                console.error('Get session error:', error);
+            }
             return { data: { session: null }, error: error.message };
         }
         


### PR DESCRIPTION
## Summary
- avoid logging errors when Supabase session is missing

## Testing
- `npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684174d51ad083228d115c81400cde5e