### PR TITLE
Add encrypted API key storage

### DIFF
--- a/src/html/sidebar.html
+++ b/src/html/sidebar.html
@@ -104,6 +104,9 @@
                                 <span>or</span>
                                 <button id="signin-otp-button" class="link-button">Sign in with email code</button>
                             </div>
+                            <div class="auth-reset">
+                                <button id="password-reset-button" class="link-button">Forgot password?</button>
+                            </div>
                             <div class="auth-message" id="signin-message"></div>
                         </div>
 


### PR DESCRIPTION
## Summary
- encrypt user API keys with password using AES-GCM
- allow requesting password reset via Supabase
- store password in memory and wipe on sign-out
- handle decryption failures by clearing remote keys
- expose resetPassword API and add UI button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684181d4e9ec83228ea9f59c3c95a2d2