### PR TITLE
Add advanced password auth UI

### DIFF
--- a/src/html/sidebar.html
+++ b/src/html/sidebar.html
@@ -83,6 +83,18 @@
                                 <button id="show-signin-button" class="primary-button">Sign In</button>
                                 <button id="show-signup-button" class="secondary-button">Sign Up</button>
                             </div>
+                            <div class="auth-advanced-link">
+                                <button id="show-advanced-auth" class="link-button">Use password instead</button>
+                            </div>
+                        </div>
+
+                        <div class="auth-advanced-options hidden" id="auth-advanced-options">
+                            <p class="auth-description">Use password-based authentication</p>
+                            <div class="auth-buttons">
+                                <button id="show-signin-password" class="primary-button">Sign In with Password</button>
+                                <button id="show-signup-password" class="secondary-button">Sign Up with Password</button>
+                            </div>
+                            <button id="advanced-auth-cancel" class="link-button">Back</button>
                         </div>
 
                         <!-- Sign In Form -->

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -540,6 +540,16 @@ body {
     color: #1557b0;
 }
 
+.auth-advanced-link {
+    margin-top: 8px;
+    text-align: center;
+}
+
+.auth-advanced-options {
+    margin-top: 16px;
+    text-align: center;
+}
+
 .otp-instructions {
     font-size: 14px;
     color: #666;


### PR DESCRIPTION
## Summary
- add advanced authentication buttons to show password-based forms
- style advanced auth sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684185bd2fb48322a9ad6bc8b12452de